### PR TITLE
Build multi-tab vet diagnostics experience

### DIFF
--- a/vetdiagnostics/AIDiagnosticView.swift
+++ b/vetdiagnostics/AIDiagnosticView.swift
@@ -1,0 +1,213 @@
+import SwiftUI
+
+struct AIDiagnosticView: View {
+    @State private var selectedStage = 0
+    @State private var selectedPetIndex = 0
+    @State private var symptomSeverity = 2
+    @State private var symptomNotes = ""
+    @State private var includeVitals = true
+    @State private var showOverlay = false
+    @State private var showAlert = false
+    @State private var showMailComposer = false
+
+    private let pets = ["Luna", "Atlas", "Nova"]
+    private let stages = ["Intake", "Vitals", "Summary"]
+
+    var body: some View {
+        ZStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    header
+                    stageSelector
+                    intakeSection
+                    vitalsSection
+                    summarySection
+                }
+                .padding(20)
+            }
+            .background(AppColor.background.ignoresSafeArea())
+
+            if showOverlay {
+                MockResultOverlay(showOverlay: $showOverlay, showMailComposer: $showMailComposer)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityAddTraits(.isModal)
+            }
+        }
+        .navigationTitle("AI Diagnostic")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showAlert = true
+                } label: {
+                    Label("Safety", systemImage: "exclamationmark.shield")
+                }
+            }
+        }
+        .alert("AI safety", isPresented: $showAlert) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Remember to confirm AI recommendations with clinical judgment before proceeding.")
+        }
+        .sheet(isPresented: $showMailComposer) {
+            MailComposerView(isPresented: $showMailComposer, subject: "Report Diagnostic Issue", body: "I'd like to report a potential issue with the AI diagnostic result.")
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Guided triage")
+                .font(AppTypography.title)
+                .fontWeight(.bold)
+            Text("Capture the latest observations, adjust weightings, and let the AI surface probable conditions with confidence scores.")
+                .font(AppTypography.body)
+                .foregroundColor(.secondary)
+        }
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(AppColor.primaryGradient)
+        )
+        .foregroundColor(.white)
+        .shadow(color: AppColor.accent.opacity(0.2), radius: 22, x: 0, y: 14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("Guided triage introduction"))
+    }
+
+    private var stageSelector: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Workflow stage")
+                .font(AppTypography.headline)
+            AppSegmentedControl(selection: $selectedStage, options: stages)
+        }
+    }
+
+    private var intakeSection: some View {
+        AppCard(title: "1. Intake details", subtitle: "Select the patient and capture present symptoms") {
+            Picker("Pet", selection: $selectedPetIndex) {
+                ForEach(petOptions) { option in
+                    Text(option.name)
+                        .tag(option.id)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("Pet selection")
+
+            Stepper(value: $symptomSeverity, in: 0...4) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Symptom intensity")
+                        .font(AppTypography.subheadline)
+                    Text(SymptomSeverity(rawValue: symptomSeverity)?.description ?? "")
+                        .font(AppTypography.footnote)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .accessibilityLabel("Symptom intensity stepper")
+
+            AppTextEditor(title: "Observation notes", text: $symptomNotes)
+                .accessibilityHint("Describe symptoms in detail")
+        }
+    }
+
+    private var vitalsSection: some View {
+        AppCard(title: "2. Vitals weighting", subtitle: "Toggle sensor data to include in this run") {
+            Toggle(isOn: $includeVitals) {
+                Text("Include wearable vitals stream")
+                    .font(AppTypography.body)
+            }
+            .toggleStyle(SwitchToggleStyle(tint: AppColor.accent))
+            .accessibilityLabel("Include wearable vitals stream")
+
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(MockVital.all) { vital in
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(vital.name)
+                                .font(AppTypography.headline)
+                            Text(vital.details)
+                                .font(AppTypography.footnote)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        StatusBadge(text: vital.badge, style: vital.badgeStyle)
+                    }
+                }
+            }
+        }
+    }
+
+    private var summarySection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("3. Review & run")
+                .font(AppTypography.headline)
+            AppCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Label("Selected pet", systemImage: "pawprint.fill")
+                        Spacer()
+                        Text(pets[selectedPetIndex])
+                            .fontWeight(.semibold)
+                    }
+                    Divider()
+                    HStack {
+                        Label("Symptom intensity", systemImage: "thermometer")
+                        Spacer()
+                        Text(SymptomSeverity(rawValue: symptomSeverity)?.description ?? "")
+                    }
+                    Divider()
+                    HStack {
+                        Label("Vitals included", systemImage: includeVitals ? "waveform.path.ecg" : "slash.circle")
+                        Spacer()
+                        Text(includeVitals ? "Enabled" : "Disabled")
+                            .foregroundColor(includeVitals ? AppColor.accent : .secondary)
+                    }
+                }
+            }
+            PrimaryGradientButton(title: "Run analysis", action: runAnalysis, icon: "sparkles")
+        }
+    }
+
+    private func runAnalysis() {
+        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
+            showOverlay = true
+        }
+    }
+}
+
+private enum SymptomSeverity: Int {
+    case none = 0, mild, moderate, high, emergency
+
+    var description: String {
+        switch self {
+        case .none: return "No notable issues"
+        case .mild: return "Mild"
+        case .moderate: return "Moderate"
+        case .high: return "High"
+        case .emergency: return "Emergency"
+        }
+    }
+}
+
+private struct MockVital: Identifiable {
+    let id = UUID()
+    let name: String
+    let details: String
+    let badge: String
+    let badgeStyle: StatusBadge.Style
+
+    static let all: [MockVital] = [
+        MockVital(name: "Heart rate", details: "92 BPM · Slightly elevated", badge: "+6%", badgeStyle: .warning),
+        MockVital(name: "Respiration", details: "26 RPM · Within target", badge: "Stable", badgeStyle: .success),
+        MockVital(name: "Temperature", details: "102.1°F · Rising", badge: "Alert", badgeStyle: .warning)
+    ]
+}
+
+private extension AIDiagnosticView {
+    struct PetOption: Identifiable {
+        let id: Int
+        let name: String
+    }
+
+    var petOptions: [PetOption] {
+        pets.enumerated().map { PetOption(id: $0.offset, name: $0.element) }
+    }
+}

--- a/vetdiagnostics/ContentView.swift
+++ b/vetdiagnostics/ContentView.swift
@@ -9,13 +9,29 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            NavigationStack {
+                HomeView()
+            }
+            .tabItem {
+                Label("Home", systemImage: "house.fill")
+            }
+
+            NavigationStack {
+                AIDiagnosticView()
+            }
+            .tabItem {
+                Label("AI Diagnostic", systemImage: "stethoscope")
+            }
+
+            NavigationStack {
+                ProfileView()
+            }
+            .tabItem {
+                Label("Profile", systemImage: "person.crop.circle")
+            }
         }
-        .padding()
+        .accentColor(AppColor.accent)
     }
 }
 

--- a/vetdiagnostics/DesignSystem.swift
+++ b/vetdiagnostics/DesignSystem.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+enum AppColor {
+    static let accent = Color(red: 0.03, green: 0.58, blue: 0.65)
+    static let accentSecondary = Color(red: 0.45, green: 0.75, blue: 0.75)
+    static let background = Color(.systemBackground)
+    static let surface = Color(.secondarySystemBackground)
+    static let separator = Color(.separator)
+    static let success = Color(red: 0.26, green: 0.64, blue: 0.39)
+    static let warning = Color(red: 0.95, green: 0.75, blue: 0.10)
+    static let danger = Color(red: 0.82, green: 0.23, blue: 0.26)
+
+    static var primaryGradient: LinearGradient {
+        LinearGradient(
+            colors: [accent, accentSecondary],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    static var subtleGradient: LinearGradient {
+        LinearGradient(
+            colors: [Color(.systemGray6), Color(.systemGray5)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+}
+
+enum AppTypography {
+    static var largeTitle: Font { .system(.largeTitle, design: .rounded) }
+    static var title: Font { .system(.title, design: .rounded) }
+    static var title2: Font { .system(.title2, design: .rounded) }
+    static var headline: Font { .system(.headline, design: .rounded) }
+    static var body: Font { .system(.body, design: .rounded) }
+    static var subheadline: Font { .system(.subheadline, design: .rounded) }
+    static var footnote: Font { .system(.footnote, design: .rounded) }
+}
+
+struct AppCard<Content: View>: View {
+    let title: String?
+    let subtitle: String?
+    let action: (() -> Void)?
+    @ViewBuilder let content: Content
+
+    init(title: String? = nil, subtitle: String? = nil, action: (() -> Void)? = nil, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.subtitle = subtitle
+        self.action = action
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let title {
+                Text(title)
+                    .font(AppTypography.headline)
+                    .foregroundColor(.primary)
+                    .accessibilityAddTraits(.isHeader)
+            }
+            if let subtitle {
+                Text(subtitle)
+                    .font(AppTypography.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            content
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.secondarySystemBackground))
+                .shadow(color: Color.black.opacity(0.08), radius: 12, x: 0, y: 8)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(AppColor.separator.opacity(0.4))
+        )
+        .contentShape(Rectangle())
+        .onTapGesture {
+            action?()
+        }
+    }
+}
+
+struct PrimaryGradientButton: View {
+    let title: String
+    let action: () -> Void
+    var icon: String? = nil
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                if let icon {
+                    Image(systemName: icon)
+                        .imageScale(.medium)
+                }
+                Text(title)
+                    .font(AppTypography.headline)
+                    .fontWeight(.semibold)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .foregroundColor(.white)
+            .padding(.horizontal, 24)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity)
+            .background(
+                Capsule()
+                    .fill(AppColor.primaryGradient)
+            )
+            .shadow(color: AppColor.accent.opacity(0.3), radius: 12, x: 0, y: 8)
+        }
+        .accessibilityLabel(Text(title))
+    }
+}
+
+struct StatusBadge: View {
+    enum Style {
+        case success, warning, info
+
+        var colors: (foreground: Color, background: Color) {
+            switch self {
+            case .success:
+                return (AppColor.success, AppColor.success.opacity(0.15))
+            case .warning:
+                return (AppColor.warning, AppColor.warning.opacity(0.2))
+            case .info:
+                return (AppColor.accent, AppColor.accent.opacity(0.15))
+            }
+        }
+    }
+
+    let text: String
+    var style: Style = .info
+
+    var body: some View {
+        Text(text)
+            .font(AppTypography.footnote)
+            .fontWeight(.semibold)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(style.colors.background)
+            )
+            .foregroundColor(style.colors.foreground)
+            .accessibilityLabel(Text(text))
+    }
+}
+
+struct AppSegmentedControl: View {
+    @Binding var selection: Int
+    let options: [String]
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(items) { option in
+                Button {
+                    selection = option.id
+                } label: {
+                    Text(option.title)
+                        .font(AppTypography.subheadline)
+                        .fontWeight(.semibold)
+                        .padding(.vertical, 10)
+                        .frame(maxWidth: .infinity)
+                        .background(
+                            Group {
+                                if selection == option.id {
+                                    Capsule().fill(AppColor.accent.opacity(0.15))
+                                } else {
+                                    Capsule().fill(Color.clear)
+                                }
+                            }
+                        )
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(selection == option.id ? AppColor.accent : .secondary)
+                .accessibilityLabel(Text(option.title))
+            }
+        }
+        .padding(6)
+        .background(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(Color(.tertiarySystemBackground))
+        )
+    }
+}
+
+extension AppSegmentedControl {
+    struct Option: Identifiable {
+        let id: Int
+        let title: String
+    }
+
+    var items: [Option] {
+        options.enumerated().map { Option(id: $0.offset, title: $0.element) }
+    }
+}
+
+struct AppTextField: View {
+    let title: String
+    @Binding var text: String
+    var prompt: String = ""
+    var symbol: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(AppTypography.subheadline)
+                .foregroundColor(.secondary)
+            HStack {
+                if let symbol {
+                    Image(systemName: symbol)
+                        .foregroundColor(.secondary)
+                }
+                TextField(prompt, text: $text)
+                    .textFieldStyle(.plain)
+                    .font(AppTypography.body)
+                    .accessibilityLabel(Text(title))
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color(.tertiarySystemFill))
+            )
+        }
+    }
+}
+
+struct AppTextEditor: View {
+    let title: String
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(AppTypography.subheadline)
+                .foregroundColor(.secondary)
+            TextEditor(text: $text)
+                .frame(minHeight: 120)
+                .padding(10)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color(.tertiarySystemFill))
+                )
+                .accessibilityLabel(Text(title))
+        }
+    }
+}

--- a/vetdiagnostics/DiagnosisDetailView.swift
+++ b/vetdiagnostics/DiagnosisDetailView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+struct DiagnosisDetailView: View {
+    let summary: DiagnosisSummary
+    @State private var showResourceSheet = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                header
+                metrics
+                recommendations
+            }
+            .padding(20)
+        }
+        .background(AppColor.background.ignoresSafeArea())
+        .navigationTitle(summary.petName)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showResourceSheet.toggle()
+                } label: {
+                    Label("Resources", systemImage: "doc.text.magnifyingglass")
+                        .labelStyle(.iconOnly)
+                }
+                .accessibilityLabel("View related resources")
+            }
+        }
+        .sheet(isPresented: $showResourceSheet) {
+            NavigationStack {
+                ResourceListView(resources: Resource.mock)
+                    .navigationTitle("Resources")
+                    .toolbar {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Button("Done") {
+                                showResourceSheet = false
+                            }
+                        }
+                    }
+            }
+            .presentationDetents([.medium, .large])
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(summary.brief)
+                    .font(AppTypography.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+                StatusBadge(text: summary.status.rawValue, style: summary.status.badgeStyle)
+            }
+            Label(summary.timestamp, systemImage: "clock")
+                .font(AppTypography.footnote)
+                .foregroundColor(.secondary)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                .fill(AppColor.primaryGradient)
+        )
+        .foregroundColor(.white)
+        .shadow(color: AppColor.accent.opacity(0.2), radius: 22, x: 0, y: 14)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Text("Summary: \(summary.brief)"))
+    }
+
+    private var metrics: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Key signals")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+            VStack(spacing: 16) {
+                ForEach(MockSignal.all) { signal in
+                    AppCard(title: signal.title, subtitle: signal.subtitle) {
+                        HStack(alignment: .center, spacing: 12) {
+                            Gauge(value: signal.percentage)
+                                .frame(width: 70, height: 70)
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(signal.description)
+                                    .font(AppTypography.body)
+                                    .foregroundColor(.secondary)
+                                StatusBadge(text: signal.status, style: signal.badgeStyle)
+                            }
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+            }
+        }
+    }
+
+    private var recommendations: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Care recommendations")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+            AppCard {
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(summary.noteItems) { note in
+                        HStack(alignment: .top, spacing: 8) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(AppColor.accent)
+                            Text(note.text)
+                                .font(AppTypography.body)
+                                .foregroundColor(.primary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private struct Gauge: View {
+    let value: Double
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .trim(from: 0, to: 1)
+                .stroke(AppColor.accent.opacity(0.15), style: StrokeStyle(lineWidth: 8, lineCap: .round))
+            Circle()
+                .trim(from: 0, to: value)
+                .stroke(AppColor.primaryGradient, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+            Text("\(Int(value * 100))%")
+                .font(AppTypography.subheadline)
+                .fontWeight(.semibold)
+        }
+        .padding(8)
+        .accessibilityLabel(Text("Confidence \(Int(value * 100)) percent"))
+    }
+}
+
+private struct MockSignal: Identifiable {
+    let id = UUID()
+    let title: String
+    let subtitle: String
+    let description: String
+    let percentage: Double
+    let status: String
+    let badgeStyle: StatusBadge.Style
+
+    static let all: [MockSignal] = [
+        MockSignal(title: "Respiration", subtitle: "AI confidence", description: "Breathing stabilized within expected range.", percentage: 0.82, status: "Stable", badgeStyle: .success),
+        MockSignal(title: "Temperature", subtitle: "Trend deviation", description: "Slight elevation persists — reassess in clinic.", percentage: 0.64, status: "Monitor", badgeStyle: .warning),
+        MockSignal(title: "Activity", subtitle: "Movement index", description: "Mobility readings suggest mild stiffness after rest.", percentage: 0.48, status: "Watch", badgeStyle: .info)
+    ]
+}

--- a/vetdiagnostics/HomeView.swift
+++ b/vetdiagnostics/HomeView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+
+struct HomeView: View {
+    private let featuredTips: [CareTip] = CareTip.mock
+    private let recentAnalyses: [DiagnosisSummary] = DiagnosisSummary.mock
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                heroHeader
+                quickActions
+                insightsSection
+                resourceSection
+            }
+            .padding(.horizontal, 20)
+            .padding(.bottom, 40)
+            .padding(.top, 12)
+        }
+        .background(AppColor.background.ignoresSafeArea())
+        .navigationTitle("Welcome")
+        .toolbarBackground(AppColor.background, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
+    }
+
+    private var heroHeader: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("AI-Powered Care")
+                .font(AppTypography.largeTitle)
+                .fontWeight(.bold)
+            Text("Run quick diagnostics, review insights, and keep pets healthy with real-time recommendations.")
+                .font(AppTypography.body)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .fill(AppColor.primaryGradient)
+        )
+        .overlay(alignment: .topTrailing) {
+            StatusBadge(text: "New Insights", style: .info)
+                .padding(16)
+        }
+        .foregroundColor(.white)
+        .shadow(color: AppColor.accent.opacity(0.25), radius: 24, x: 0, y: 16)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("AI-powered care overview")
+    }
+
+    private var quickActions: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Quick actions")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+            VStack(spacing: 16) {
+                NavigationLink {
+                    AIDiagnosticView()
+                } label: {
+                    AppCard(title: "Start new diagnostic", subtitle: "Launch AI triage in under two minutes") {
+                        HStack {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Label("Realtime vitals", systemImage: "waveform.path.ecg")
+                                    .font(AppTypography.footnote)
+                                    .foregroundColor(.secondary)
+                                Label("Symptom comparison", systemImage: "list.bullet.rectangle")
+                                    .font(AppTypography.footnote)
+                                    .foregroundColor(.secondary)
+                            }
+                            Spacer()
+                            Image(systemName: "arrow.right.circle.fill")
+                                .imageScale(.large)
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+
+                NavigationLink {
+                    ResourceListView(resources: Resource.mock)
+                } label: {
+                    AppCard(title: "Clinical resources", subtitle: "Access evidence-based protocols") {
+                        HStack {
+                            StatusBadge(text: "Updated")
+                            Spacer()
+                            Image(systemName: "book.pages.fill")
+                                .imageScale(.large)
+                                .foregroundColor(AppColor.accent)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var insightsSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Latest analyses")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+            VStack(spacing: 16) {
+                ForEach(recentAnalyses) { summary in
+                    NavigationLink {
+                        DiagnosisDetailView(summary: summary)
+                    } label: {
+                        AppCard {
+                            VStack(alignment: .leading, spacing: 8) {
+                                HStack {
+                                    Text(summary.petName)
+                                        .font(AppTypography.headline)
+                                    Spacer()
+                                    StatusBadge(text: summary.status.rawValue, style: summary.status.badgeStyle)
+                                }
+                                Text(summary.brief)
+                                    .font(AppTypography.body)
+                                    .foregroundColor(.secondary)
+                                HStack {
+                                    Label(summary.timestamp, systemImage: "clock")
+                                        .font(AppTypography.footnote)
+                                        .foregroundColor(.secondary)
+                                    Spacer()
+                                    Image(systemName: "chevron.right")
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var resourceSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Care tips")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 16) {
+                    ForEach(featuredTips) { tip in
+                        VStack(alignment: .leading, spacing: 12) {
+                            StatusBadge(text: tip.category, style: .info)
+                            Text(tip.title)
+                                .font(AppTypography.headline)
+                                .foregroundColor(.primary)
+                            Text(tip.description)
+                                .font(AppTypography.subheadline)
+                                .foregroundColor(.secondary)
+                                .lineLimit(3)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .padding(20)
+                        .frame(width: 260, alignment: .leading)
+                        .background(
+                            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                                .fill(AppColor.surface)
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 24, style: .continuous)
+                                .stroke(AppColor.separator.opacity(0.3))
+                        )
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text("Care tip: \(tip.title)"))
+                    }
+                }
+                .padding(.trailing, 20)
+            }
+        }
+    }
+}
+
+struct CareTip: Identifiable {
+    let id = UUID()
+    let category: String
+    let title: String
+    let description: String
+
+    static let mock: [CareTip] = [
+        CareTip(category: "Hydration", title: "Monitor fluid intake", description: "Encourage regular hydration post-treatment to support renal function and avoid dehydration."),
+        CareTip(category: "Mobility", title: "Gradual exercise", description: "Plan two short leash walks with light stretching to rebuild muscle without overexertion."),
+        CareTip(category: "Nutrition", title: "High-protein snacks", description: "Offer small, protein-rich snacks spaced throughout the day to maintain energy between meals.")
+    ]
+}
+
+struct DiagnosisSummary: Identifiable {
+    enum Status: String {
+        case stable = "Stable"
+        case monitor = "Monitor"
+        case urgent = "Urgent"
+
+        var badgeStyle: StatusBadge.Style {
+            switch self {
+            case .stable:
+                return .success
+            case .monitor:
+                return .warning
+            case .urgent:
+                return .warning
+            }
+        }
+    }
+
+    let id = UUID()
+    let petName: String
+    let brief: String
+    let timestamp: String
+    let status: Status
+    let notes: [String]
+
+    struct NoteItem: Identifiable {
+        let id: Int
+        let text: String
+    }
+
+    var noteItems: [NoteItem] {
+        notes.enumerated().map { NoteItem(id: $0.offset, text: $0.element) }
+    }
+
+    static let mock: [DiagnosisSummary] = [
+        DiagnosisSummary(
+            petName: "Luna",
+            brief: "Respiratory rate normalized after bronchodilator therapy.",
+            timestamp: "20 min ago",
+            status: .stable,
+            notes: ["Continue monitoring at-home inhaler usage", "Schedule follow-up in 48 hours"]
+        ),
+        DiagnosisSummary(
+            petName: "Atlas",
+            brief: "Mild GI distress detected from symptom clustering.",
+            timestamp: "1 hr ago",
+            status: .monitor,
+            notes: ["Recommend bland diet for 24 hours", "Flag recurrence for deeper scan"]
+        ),
+        DiagnosisSummary(
+            petName: "Nova",
+            brief: "Elevated temperature trending upward — watch closely.",
+            timestamp: "Yesterday",
+            status: .urgent,
+            notes: ["Re-run vitals in clinic", "Consider anti-inflammatory protocol"]
+        )
+    ]
+}

--- a/vetdiagnostics/OverlayViews.swift
+++ b/vetdiagnostics/OverlayViews.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+import MessageUI
+import UIKit
+
+struct MockResultOverlay: View {
+    @Binding var showOverlay: Bool
+    @Binding var showMailComposer: Bool
+    private let result = MockResult.sample
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Color.black.opacity(0.35)
+                .ignoresSafeArea()
+                .onTapGesture {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        showOverlay = false
+                    }
+                }
+                .accessibilityLabel("Dismiss results")
+
+            VStack(spacing: 20) {
+                Capsule()
+                    .frame(width: 60, height: 6)
+                    .foregroundColor(.secondary.opacity(0.6))
+                    .padding(.top, 12)
+
+                VStack(alignment: .leading, spacing: 20) {
+                    HStack {
+                        Text("Preliminary results")
+                            .font(AppTypography.title2)
+                            .fontWeight(.bold)
+                        Spacer()
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                showOverlay = false
+                            }
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .imageScale(.large)
+                                .foregroundColor(.secondary)
+                        }
+                        .accessibilityLabel("Close results")
+                    }
+
+                    AppCard(title: result.primaryCondition, subtitle: "Confidence \(Int(result.confidence * 100))%") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            Text(result.description)
+                                .font(AppTypography.body)
+                                .foregroundColor(.primary)
+                            NavigationLink {
+                                DiagnosisDetailView(summary: result.summary)
+                            } label: {
+                                Label("View diagnostic timeline", systemImage: "chevron.right")
+                                    .foregroundColor(AppColor.accent)
+                                    .font(AppTypography.subheadline)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    AppCard(title: "Next steps", subtitle: "Suggested interventions") {
+                        VStack(alignment: .leading, spacing: 10) {
+                            ForEach(result.stepItems) { step in
+                                HStack(alignment: .top, spacing: 8) {
+                                    Image(systemName: "circle.fill")
+                                        .font(.system(size: 6))
+                                        .foregroundColor(AppColor.accent)
+                                    Text(step.text)
+                                        .font(AppTypography.body)
+                                        .foregroundColor(.primary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(20)
+                .background(
+                    RoundedRectangle(cornerRadius: 28, style: .continuous)
+                        .fill(AppColor.background)
+                )
+                .frame(maxWidth: 640)
+                .accessibilityElement(children: .contain)
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 24)
+
+            Button {
+                showMailComposer = true
+            } label: {
+                Label("Report issue", systemImage: "envelope.badge")
+                    .font(AppTypography.subheadline)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                    .background(
+                        Capsule()
+                            .fill(AppColor.primaryGradient)
+                    )
+                    .foregroundColor(.white)
+                    .shadow(color: AppColor.accent.opacity(0.3), radius: 12, x: 0, y: 6)
+            }
+            .padding(.trailing, 28)
+            .padding(.bottom, 44)
+            .accessibilityLabel("Report issue via email")
+        }
+    }
+}
+
+struct MailComposerView: UIViewControllerRepresentable {
+    @Environment(\.dismiss) private var dismiss
+    @Binding var isPresented: Bool
+    let subject: String
+    let body: String
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        guard MFMailComposeViewController.canSendMail() else {
+            let alert = UIAlertController(title: "Mail unavailable", message: "Configure a mail account on this device to send feedback.", preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: "OK", style: .default) { _ in
+                dismiss()
+                isPresented = false
+            })
+            return alert
+        }
+
+        let controller = MFMailComposeViewController()
+        controller.mailComposeDelegate = context.coordinator
+        controller.setSubject(subject)
+        controller.setMessageBody(body, isHTML: false)
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+        let parent: MailComposerView
+
+        init(parent: MailComposerView) {
+            self.parent = parent
+        }
+
+        func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+            controller.dismiss(animated: true) {
+                parent.isPresented = false
+            }
+        }
+    }
+}
+
+private struct MockResult {
+    let primaryCondition: String
+    let confidence: Double
+    let description: String
+    let nextSteps: [String]
+    let summary: DiagnosisSummary
+
+    struct Step: Identifiable {
+        let id: Int
+        let text: String
+    }
+
+    var stepItems: [Step] {
+        nextSteps.enumerated().map { Step(id: $0.offset, text: $0.element) }
+    }
+
+    static let sample = MockResult(
+        primaryCondition: "Upper respiratory inflammation",
+        confidence: 0.78,
+        description: "AI detected consistent bronchial inflammation patterns similar to previous cases with positive steroid response.",
+        nextSteps: [
+            "Schedule in-clinic follow-up within 24 hours.",
+            "Share inhaler usage plan with caregiver via the app.",
+            "Flag case for manual specialist review."
+        ],
+        summary: DiagnosisSummary.mock.first ?? DiagnosisSummary(
+            petName: "Luna",
+            brief: "Respiratory rate normalized after bronchodilator therapy.",
+            timestamp: "20 min ago",
+            status: .stable,
+            notes: ["Continue monitoring at-home inhaler usage", "Schedule follow-up in 48 hours"]
+        )
+    )
+}

--- a/vetdiagnostics/ProfileView.swift
+++ b/vetdiagnostics/ProfileView.swift
@@ -1,0 +1,228 @@
+import SwiftUI
+
+struct ProfileView: View {
+    @State private var pets: [PetProfile] = PetProfile.mock
+    @State private var showAddSheet = false
+    @State private var editingPet: PetProfile? = nil
+    @State private var showResources = false
+
+    var body: some View {
+        List {
+            Section(header: Text("My pets")) {
+                ForEach(pets) { pet in
+                    Button {
+                        editingPet = pet
+                    } label: {
+                        PetRow(pet: pet)
+                    }
+                    .buttonStyle(.plain)
+                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                        Button(role: .destructive) {
+                            withAnimation {
+                                pets.removeAll { $0.id == pet.id }
+                            }
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+
+            Section {
+                NavigationLink {
+                    SettingsView()
+                } label: {
+                    Label("Account settings", systemImage: "gear")
+                }
+
+                Button {
+                    showResources = true
+                } label: {
+                    Label("Care resources", systemImage: "book")
+                }
+                .sheet(isPresented: $showResources) {
+                    NavigationStack {
+                        ResourceListView(resources: Resource.mock)
+                            .navigationTitle("Care resources")
+                            .toolbar {
+                                ToolbarItem(placement: .navigationBarTrailing) {
+                                    Button("Done") {
+                                        showResources = false
+                                    }
+                                }
+                            }
+                    }
+                }
+            }
+        }
+        .background(AppColor.background)
+        .navigationTitle("Profile")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    showAddSheet = true
+                } label: {
+                    Label("Add pet", systemImage: "plus")
+                }
+            }
+        }
+        .sheet(isPresented: $showAddSheet) {
+            NavigationStack {
+                PetEditorView(pet: .constant(PetProfile.empty)) { newPet in
+                    pets.append(newPet)
+                    showAddSheet = false
+                }
+                .navigationTitle("Add pet")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") {
+                            showAddSheet = false
+                        }
+                    }
+                }
+            }
+        }
+        .sheet(item: $editingPet) { pet in
+            NavigationStack {
+                PetEditorView(pet: .constant(pet)) { updatedPet in
+                    if let index = pets.firstIndex(where: { $0.id == updatedPet.id }) {
+                        pets[index] = updatedPet
+                    }
+                    editingPet = nil
+                }
+                .navigationTitle("Edit pet")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel") {
+                            editingPet = nil
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct PetRow: View {
+    let pet: PetProfile
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Circle()
+                .fill(AppColor.primaryGradient)
+                .frame(width: 48, height: 48)
+                .overlay(
+                    Text(String(pet.name.prefix(1)))
+                        .font(AppTypography.headline)
+                        .foregroundColor(.white)
+                )
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(pet.name)
+                    .font(AppTypography.headline)
+                Text("\(pet.species) · \(pet.age) yrs")
+                    .font(AppTypography.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(pet.name), \(pet.species), \(pet.age) years old")
+    }
+}
+
+struct SettingsView: View {
+    @State private var notificationsEnabled = true
+    @State private var shareAnalytics = false
+
+    var body: some View {
+        Form {
+            Section(header: Text("Notifications")) {
+                Toggle(isOn: $notificationsEnabled) {
+                    Text("Care alerts")
+                }
+                Toggle(isOn: $shareAnalytics) {
+                    Text("Share anonymized analytics")
+                }
+            }
+
+            Section(header: Text("About")) {
+                Text("VetDiagnostics v1.0")
+                Text("Support: support@vetdiagnostics.example")
+            }
+        }
+    }
+}
+
+struct PetEditorView: View {
+    @State private var draft: PetProfile
+    let onSave: (PetProfile) -> Void
+
+    init(pet: Binding<PetProfile>, onSave: @escaping (PetProfile) -> Void) {
+        _draft = State(initialValue: pet.wrappedValue)
+        self.onSave = onSave
+    }
+
+    @State private var weight: String = ""
+
+    var body: some View {
+        Form {
+            Section(header: Text("Details")) {
+                TextField("Name", text: $draft.name)
+                TextField("Species", text: $draft.species)
+                Stepper(value: $draft.age, in: 0...30) {
+                    Text("Age: \(draft.age) years")
+                }
+            }
+
+            Section(header: Text("Vitals")) {
+                TextField("Weight (kg)", text: $weight)
+                    .keyboardType(.decimalPad)
+                TextField("Allergies", text: $draft.allergies)
+            }
+
+            Section(header: Text("Notes")) {
+                TextEditor(text: Binding(
+                    get: { draft.notes ?? "" },
+                    set: { draft.notes = $0 }
+                ))
+                .frame(minHeight: 120)
+            }
+        }
+        .onAppear {
+            weight = draft.weight ?? ""
+        }
+        .onChange(of: weight) { newValue in
+            draft.weight = newValue
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Save") {
+                    onSave(draft)
+                }
+                .disabled(draft.name.isEmpty || draft.species.isEmpty)
+            }
+        }
+    }
+}
+
+struct PetProfile: Identifiable, Equatable {
+    let id: UUID
+    var name: String
+    var species: String
+    var age: Int
+    var weight: String?
+    var allergies: String
+    var notes: String?
+
+    static var empty: PetProfile { PetProfile(id: UUID(), name: "", species: "", age: 0, weight: nil, allergies: "", notes: nil) }
+
+    static let mock: [PetProfile] = [
+        PetProfile(id: UUID(), name: "Luna", species: "Canine", age: 4, weight: "18", allergies: "Seasonal pollen", notes: "Responds well to inhaler therapy."),
+        PetProfile(id: UUID(), name: "Atlas", species: "Feline", age: 7, weight: "6", allergies: "Chicken", notes: "Prefers pill pockets for medication."),
+        PetProfile(id: UUID(), name: "Nova", species: "Canine", age: 2, weight: "22", allergies: "None", notes: "High energy, monitor post-op activity.")
+    ]
+}

--- a/vetdiagnostics/ResourceViews.swift
+++ b/vetdiagnostics/ResourceViews.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+struct ResourceListView: View {
+    let resources: [Resource]
+
+    var body: some View {
+        List {
+            Section("Protocols") {
+                ForEach(resources) { resource in
+                    NavigationLink(destination: ResourceDetailView(resource: resource)) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(resource.title)
+                                .font(AppTypography.headline)
+                            Text(resource.summary)
+                                .font(AppTypography.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 6)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text("Resource: \(resource.title)"))
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .background(AppColor.background)
+    }
+}
+
+struct ResourceDetailView: View {
+    let resource: Resource
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text(resource.title)
+                    .font(AppTypography.title)
+                    .fontWeight(.bold)
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(resource.sections) { section in
+                        AppCard(title: section.title) {
+                            VStack(alignment: .leading, spacing: 8) {
+                                ForEach(section.pointItems) { point in
+                                    HStack(alignment: .top, spacing: 8) {
+                                        Image(systemName: "star.fill")
+                                            .foregroundColor(AppColor.accent)
+                                            .font(.caption)
+                                        Text(point.text)
+                                            .font(AppTypography.body)
+                                            .foregroundColor(.primary)
+                                            .fixedSize(horizontal: false, vertical: true)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .background(AppColor.background.ignoresSafeArea())
+        .navigationTitle("Guideline")
+    }
+}
+
+struct Resource: Identifiable {
+    struct Section: Identifiable {
+        let id = UUID()
+        let title: String
+        let points: [String]
+
+        struct Point: Identifiable {
+            let id: Int
+            let text: String
+        }
+
+        var pointItems: [Point] {
+            points.enumerated().map { Point(id: $0.offset, text: $0.element) }
+        }
+    }
+
+    let id = UUID()
+    let title: String
+    let summary: String
+    let sections: [Section]
+
+    static let mock: [Resource] = [
+        Resource(
+            title: "Post-operative respiratory care",
+            summary: "Checklist for supporting patients after airway procedures.",
+            sections: [
+                Section(title: "Immediate care", points: [
+                    "Monitor respiratory effort every 15 minutes for the first hour.",
+                    "Provide humidified oxygen if saturation drops below 94%."
+                ]),
+                Section(title: "At-home guidance", points: [
+                    "Share step-down steroid tapering schedule with caregivers.",
+                    "Provide emergency triggers that should prompt clinic contact."
+                ])
+            ]
+        ),
+        Resource(
+            title: "GI distress stabilization",
+            summary: "Evidence-based interventions for acute gastrointestinal flare-ups.",
+            sections: [
+                Section(title: "Intake considerations", points: [
+                    "Recommend bland diet transition over 12 hours.",
+                    "Encourage small, frequent hydration intervals."
+                ]),
+                Section(title: "Follow-up", points: [
+                    "Schedule recheck if symptoms persist beyond 24 hours.",
+                    "Collect stool sample for lab analysis if bleeding occurs."
+                ])
+            ]
+        )
+    ]
+}

--- a/vetdiagnostics/vetdiagnosticsApp.swift
+++ b/vetdiagnostics/vetdiagnosticsApp.swift
@@ -12,6 +12,7 @@ struct vetdiagnosticsApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .tint(AppColor.accent)
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the placeholder view with a three-tab navigation structure that links to the new home, AI diagnostic, and profile flows
- introduce a shared design system with typography, gradients, cards, buttons, inputs, and badges for consistent styling across screens
- add rich SwiftUI implementations for home insights, AI diagnostic workflow, diagnosis details, resource guides, overlays, and pet profile management including sheets and alerts

## Testing
- not run (iOS build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cb3ab6a02083249f8a1b4efd6a1cd8