### PR TITLE
Refine scrolling layouts and pinned headers

### DIFF
--- a/vetdiagnostics/AIDiagnosticView.swift
+++ b/vetdiagnostics/AIDiagnosticView.swift
@@ -15,15 +15,20 @@ struct AIDiagnosticView: View {
 
     var body: some View {
         ZStack {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 24) {
+            ScrollView(.vertical, showsIndicators: false) {
+                LazyVStack(alignment: .leading, spacing: 16, pinnedViews: [.sectionHeaders]) {
                     header
-                    stageSelector
-                    intakeSection
-                    vitalsSection
-                    summarySection
+                    Section {
+                        intakeSection
+                        vitalsSection
+                        summarySection
+                    } header: {
+                        stageHeader
+                    }
                 }
-                .padding(20)
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .padding(.bottom, 32)
             }
             .background(AppColor.background.ignoresSafeArea())
 
@@ -62,7 +67,7 @@ struct AIDiagnosticView: View {
                 .font(AppTypography.body)
                 .foregroundColor(.secondary)
         }
-        .padding(20)
+        .padding(16)
         .background(
             RoundedRectangle(cornerRadius: 24, style: .continuous)
                 .fill(AppColor.primaryGradient)
@@ -73,12 +78,14 @@ struct AIDiagnosticView: View {
         .accessibilityLabel(Text("Guided triage introduction"))
     }
 
-    private var stageSelector: some View {
+    private var stageHeader: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Workflow stage")
                 .font(AppTypography.headline)
             AppSegmentedControl(selection: $selectedStage, options: stages)
         }
+        .padding(16)
+        .background(AppColor.background)
     }
 
     private var intakeSection: some View {

--- a/vetdiagnostics/HomeView.swift
+++ b/vetdiagnostics/HomeView.swift
@@ -5,18 +5,27 @@ struct HomeView: View {
     private let recentAnalyses: [DiagnosisSummary] = DiagnosisSummary.mock
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                heroHeader
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(alignment: .leading, spacing: 16) {
                 quickActions
                 insightsSection
                 resourceSection
             }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 40)
-            .padding(.top, 12)
+            .padding(.horizontal, 16)
+            .padding(.top, 16)
+            .padding(.bottom, 32)
         }
         .background(AppColor.background.ignoresSafeArea())
+        .safeAreaInset(edge: .top, spacing: 0) {
+            heroHeader
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+                .padding(.bottom, 12)
+                .background(
+                    AppColor.background
+                        .shadow(color: AppColor.accent.opacity(0.1), radius: 18, x: 0, y: 8)
+                )
+        }
         .navigationTitle("Welcome")
         .toolbarBackground(AppColor.background, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)

--- a/vetdiagnostics/ProfileView.swift
+++ b/vetdiagnostics/ProfileView.swift
@@ -7,55 +7,15 @@ struct ProfileView: View {
     @State private var showResources = false
 
     var body: some View {
-        List {
-            Section(header: Text("My pets")) {
-                ForEach(pets) { pet in
-                    Button {
-                        editingPet = pet
-                    } label: {
-                        PetRow(pet: pet)
-                    }
-                    .buttonStyle(.plain)
-                    .swipeActions(edge: .trailing, allowsFullSwipe: true) {
-                        Button(role: .destructive) {
-                            withAnimation {
-                                pets.removeAll { $0.id == pet.id }
-                            }
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
-                    }
-                }
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .leading, spacing: 16) {
+                petRosterSection
+                accountActions
             }
-
-            Section {
-                NavigationLink {
-                    SettingsView()
-                } label: {
-                    Label("Account settings", systemImage: "gear")
-                }
-
-                Button {
-                    showResources = true
-                } label: {
-                    Label("Care resources", systemImage: "book")
-                }
-                .sheet(isPresented: $showResources) {
-                    NavigationStack {
-                        ResourceListView(resources: Resource.mock)
-                            .navigationTitle("Care resources")
-                            .toolbar {
-                                ToolbarItem(placement: .navigationBarTrailing) {
-                                    Button("Done") {
-                                        showResources = false
-                                    }
-                                }
-                            }
-                    }
-                }
-            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 24)
         }
-        .background(AppColor.background)
+        .background(AppColor.background.ignoresSafeArea())
         .navigationTitle("Profile")
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -100,6 +60,105 @@ struct ProfileView: View {
                 }
             }
         }
+    }
+
+    private var petRosterSection: some View {
+        AppCard(title: "My pets", subtitle: "Tap a profile to view or edit details.") {
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVStack(spacing: 12) {
+                    ForEach(pets) { pet in
+                        Button {
+                            editingPet = pet
+                        } label: {
+                            PetRow(pet: pet)
+                                .padding(16)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(
+                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                        .fill(AppColor.surface)
+                                )
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                                        .stroke(AppColor.separator.opacity(0.2))
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                withAnimation {
+                                    pets.removeAll { $0.id == pet.id }
+                                }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .frame(maxHeight: 260)
+        }
+    }
+
+    private var accountActions: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Account & resources")
+                .font(AppTypography.title2)
+                .fontWeight(.semibold)
+
+            VStack(spacing: 12) {
+                NavigationLink {
+                    SettingsView()
+                } label: {
+                    actionRow(title: "Account settings", systemImage: "gear")
+                }
+                .buttonStyle(.plain)
+
+                Button {
+                    showResources = true
+                } label: {
+                    actionRow(title: "Care resources", systemImage: "book")
+                }
+                .buttonStyle(.plain)
+                .sheet(isPresented: $showResources) {
+                    NavigationStack {
+                        ResourceListView(resources: Resource.mock)
+                            .navigationTitle("Care resources")
+                            .toolbar {
+                                ToolbarItem(placement: .navigationBarTrailing) {
+                                    Button("Done") {
+                                        showResources = false
+                                    }
+                                }
+                            }
+                    }
+                }
+            }
+        }
+    }
+
+    private func actionRow(title: String, systemImage: String) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: systemImage)
+                .imageScale(.medium)
+                .foregroundColor(AppColor.accent)
+            Text(title)
+                .font(AppTypography.body)
+                .fontWeight(.semibold)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .foregroundColor(.secondary)
+        }
+        .padding(16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .fill(AppColor.surface)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(AppColor.separator.opacity(0.2))
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- convert home dashboard to a vertically scrolling layout with a pinned hero header and tighter spacing
- update the AI diagnostic flow to use a pinned stage selector while aligning padding with the new scroll treatment
- rebuild the profile screen with custom scroll containers, a bounded roster list, and refreshed action rows

## Testing
- xcodebuild -project vetdiagnostics.xcodeproj -scheme vetdiagnostics -destination 'platform=iOS Simulator,name=iPhone 14' build

------
https://chatgpt.com/codex/tasks/task_e_68cb404bbbb88324810a4269c9da68ea